### PR TITLE
feat: Add UUID support for user retrieval in UserGrpcClient

### DIFF
--- a/src/main/java/vn/vinaacademy/security/grpc/UserGrpcClient.java
+++ b/src/main/java/vn/vinaacademy/security/grpc/UserGrpcClient.java
@@ -5,6 +5,8 @@ import com.vinaacademy.grpc.GetUserByIdResponse;
 import com.vinaacademy.grpc.GetUserByIdsRequest;
 import com.vinaacademy.grpc.GetUserByIdsResponse;
 import com.vinaacademy.grpc.UserServiceGrpc.UserServiceBlockingStub;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,29 +19,29 @@ public class UserGrpcClient {
 
   /**
    * Get user information by user ID via gRPC call to platform server
-   * 
+   *
    * @param userId the user ID to fetch information for
    * @return GetUserByIdResponse containing user information or error response
    */
   public GetUserByIdResponse getUserById(String userId) {
     try {
-      GetUserByIdRequest request = GetUserByIdRequest.newBuilder()
-          .setUserId(userId)
-          .build();
-      
+      GetUserByIdRequest request = GetUserByIdRequest.newBuilder().setUserId(userId).build();
+
       log.debug("Fetching user info for userId: {}", userId);
       GetUserByIdResponse response = userServiceStub.getUserById(request);
-      
+
       if (response.getSuccess()) {
         log.debug("Successfully fetched user info for userId: {}", userId);
       } else {
-        log.warn("Failed to fetch user info for userId: {}. Message: {}", userId, response.getMessage());
+        log.warn(
+            "Failed to fetch user info for userId: {}. Message: {}", userId, response.getMessage());
       }
-      
+
       return response;
     } catch (Exception e) {
-      log.error("Error fetching user info via gRPC for userId: {}. Error: {}", userId, e.getMessage());
-      
+      log.error(
+          "Error fetching user info via gRPC for userId: {}. Error: {}", userId, e.getMessage());
+
       // Return error response
       return GetUserByIdResponse.newBuilder()
           .setSuccess(false)
@@ -48,39 +50,50 @@ public class UserGrpcClient {
     }
   }
 
+  public GetUserByIdResponse getUserById(UUID userId) {
+    return getUserById(String.valueOf(userId));
+  }
+
   /**
    * Get multiple users information by user IDs via gRPC call to platform server
-   * 
+   *
    * @param userIds the list of user IDs to fetch information for
    * @return GetUserByIdsResponse containing users information or error response
    */
-  public GetUserByIdsResponse getUserByIds(java.util.List<String> userIds) {
+  public GetUserByIdsResponse getUserByIds(List<String> userIds) {
     try {
-      GetUserByIdsRequest request = GetUserByIdsRequest.newBuilder()
-          .addAllUserIds(userIds)
-          .build();
-      
+      GetUserByIdsRequest request = GetUserByIdsRequest.newBuilder().addAllUserIds(userIds).build();
+
       log.debug("Fetching user info for userIds: {}", userIds);
       GetUserByIdsResponse response = userServiceStub.getUserByIds(request);
-      
+
       if (response.getSuccess()) {
         log.debug("Successfully fetched user info for {} users", response.getUsersCount());
         if (!response.getNotFoundIdsList().isEmpty()) {
           log.warn("Some user IDs were not found: {}", response.getNotFoundIdsList());
         }
       } else {
-        log.warn("Failed to fetch user info for userIds: {}. Message: {}", userIds, response.getMessage());
+        log.warn(
+            "Failed to fetch user info for userIds: {}. Message: {}",
+            userIds,
+            response.getMessage());
       }
-      
+
       return response;
     } catch (Exception e) {
-      log.error("Error fetching users info via gRPC for userIds: {}. Error: {}", userIds, e.getMessage());
-      
+      log.error(
+          "Error fetching users info via gRPC for userIds: {}. Error: {}", userIds, e.getMessage());
+
       // Return error response
       return GetUserByIdsResponse.newBuilder()
           .setSuccess(false)
           .setMessage("Failed to fetch users information: " + e.getMessage())
           .build();
     }
+  }
+
+  public GetUserByIdsResponse getUserByIdList(List<UUID> userIds) {
+    List<String> stringIds = userIds.stream().map(String::valueOf).toList();
+    return getUserByIds(stringIds);
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to the `UserGrpcClient` class, focusing on better support for `UUID` types and cleaner code formatting. The main changes include adding overloaded methods to handle `UUID` inputs for user ID queries and refactoring for readability.

### Support for UUID-based user ID queries

* Added a new overloaded method `getUserById(UUID userId)` to fetch user information using a `UUID` directly, delegating to the existing `getUserById(String userId)` method.
* Introduced `getUserByIdList(List<UUID> userIds)`, which converts a list of `UUID`s to strings and calls `getUserByIds(List<String> userIds)`, enabling batch queries with `UUID` inputs.

### Code formatting and cleanup

* Improved formatting and readability of log statements and request construction in both `getUserById` and `getUserByIds` methods. [[1]](diffhunk://#diff-4486abce4e17e3dab690fc30a28000254d2395170ee1bc369b3920ff25ef5e83L26-R43) [[2]](diffhunk://#diff-4486abce4e17e3dab690fc30a28000254d2395170ee1bc369b3920ff25ef5e83L72-R85)
* Updated imports to include `List` and `UUID`, reflecting the new method signatures.
* Changed the parameter type for `getUserByIds` from `java.util.List<String>` to simply `List<String>` for clarity and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to fetch a single user by UUID.
  - Added support to fetch multiple users using a list of UUIDs.
- Improvements
  - Simplified parameter types for fetching users by IDs, making integrations cleaner and more consistent for API consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->